### PR TITLE
Remove mexico enum

### DIFF
--- a/src/DB-api/environments/migrations/add_enums.sql
+++ b/src/DB-api/environments/migrations/add_enums.sql
@@ -10,8 +10,7 @@ insert into
     country (descriptor)
 VALUES
     ('US'),
-    ('CA'),
-    ('MX');
+    ('CA');
 
 insert into
     size (descriptor)


### PR DESCRIPTION
there is barely any data from mexico so we are removing mexico from the enum table.